### PR TITLE
feat: Save standard-json in broadcast files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -914,11 +914,12 @@ dependencies = [
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.6"
+version = "3.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2109dbce0e72be3ec00bed26e6a7479ca384ad226efdd66db8fa2e3a38c83125"
+checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
 dependencies = [
  "anstyle",
+ "once_cell",
  "windows-sys 0.59.0",
 ]
 
@@ -1322,9 +1323,9 @@ dependencies = [
 
 [[package]]
 name = "auto_impl"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c87f3f15e7794432337fc718554eaa4dc8f04c9677a950ffe366f20a162ae42"
+checksum = "e12882f59de5360c748c4cbf569a042d5fb0eb515f7bea9c1f470b47f6ffbd73"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1401,7 +1402,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "tracing",
- "uuid 1.11.1",
+ "uuid 1.12.0",
 ]
 
 [[package]]
@@ -2047,9 +2048,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.8"
+version = "1.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad0cf6e91fde44c773c6ee7ec6bba798504641a8bc2eb7e37a04ffbf4dfaa55a"
+checksum = "c8293772165d9345bdaaa39b45b2109591e63fe5e6fbc23c6ff930a048aa310b"
 dependencies = [
  "shlex",
 ]
@@ -3253,7 +3254,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c936bfdafb507ebbf50b8074c54fa31c5be9a1e7e5f467dd659697041407d07c"
 dependencies = [
  "crc32fast",
- "miniz_oxide 0.8.2",
+ "miniz_oxide 0.8.3",
 ]
 
 [[package]]
@@ -5403,9 +5404,9 @@ checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
 name = "jiff"
-version = "0.1.21"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed0ce60560149333a8e41ca7dc78799c47c5fd435e2bc18faf6a054382eec037"
+checksum = "7597657ea66d53f6e926a67d4cc3d125c4b57fa662f2d007a5476307de948453"
 dependencies = [
  "jiff-tzdb-platform",
  "log",
@@ -5432,9 +5433,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.76"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6717b6b5b077764fb5966237269cb3c64edddde4b14ce42647430a78ced9e7b7"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -5643,9 +5644,9 @@ checksum = "9374ef4228402d4b7e403e5838cb880d9ee663314b0a900d5a6aabf0c213552e"
 
 [[package]]
 name = "log"
-version = "0.4.22"
+version = "0.4.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
 
 [[package]]
 name = "loom"
@@ -5674,6 +5675,18 @@ name = "mac"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
+
+[[package]]
+name = "maili-common"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "717a6707a37a427e38da9cb904c1691f3ecb6538342cd9a64f8f35b8c916a367"
+dependencies = [
+ "alloy-consensus",
+ "alloy-primitives",
+ "derive_more",
+ "serde",
+]
 
 [[package]]
 name = "maplit"
@@ -5845,9 +5858,9 @@ dependencies = [
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ffbe83022cedc1d264172192511ae958937694cd57ce297164951b8b3568394"
+checksum = "b8402cab7aefae129c6977bb0ff1b8fd9a04eb5b51efc50a70bea51cda0c7924"
 dependencies = [
  "adler2",
 ]
@@ -5931,7 +5944,7 @@ version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c8781e2ef64806278a55ad223f0bc875772fd40e1fe6e73e8adbf027817229d"
 dependencies = [
- "uuid 1.11.1",
+ "uuid 1.12.0",
 ]
 
 [[package]]
@@ -6220,9 +6233,9 @@ checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
 name = "op-alloy-consensus"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "442518bf0ef88f4d79409527565b8cdee235c891f2e2a829497caec5ed9d8d1c"
+checksum = "b3c085fd93da29d79649876280e8d926ae6aa7ff5a5df7a1bd17659862822194"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6230,15 +6243,16 @@ dependencies = [
  "alloy-rlp",
  "alloy-serde",
  "derive_more",
+ "maili-common",
  "serde",
  "thiserror 2.0.11",
 ]
 
 [[package]]
 name = "op-alloy-rpc-types"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50223d61cad040db6721bcc2d489c924c1691ce3f5e674d4d8776131dab786a0"
+checksum = "16b700b5d4efbe6433abb13e52f18a5f9ffe8d8fe9aeef99912bc90ffe0d7ebc"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6746,9 +6760,9 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.27"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "483f8c21f64f3ea09fe0f30f5d48c3e8eefe5dac9129f0075f76593b4c1da705"
+checksum = "6924ced06e1f7dfe3fa48d57b9f74f55d8915f5036121bef647ef4b204895fac"
 dependencies = [
  "proc-macro2",
  "syn 2.0.96",
@@ -6853,16 +6867,16 @@ dependencies = [
 
 [[package]]
 name = "process-wrap"
-version = "8.0.2"
+version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38ee68ae331824036479c84060534b18254c864fa73366c58d86db3b7b811619"
+checksum = "d35f4dc9988d1326b065b4def5e950c3ed727aa03e3151b86cc9e2aec6b03f54"
 dependencies = [
  "futures",
  "indexmap 2.7.0",
- "nix 0.28.0",
+ "nix 0.29.0",
  "tokio",
  "tracing",
- "windows 0.56.0",
+ "windows 0.59.0",
 ]
 
 [[package]]
@@ -7001,7 +7015,7 @@ dependencies = [
  "quick-xml 0.37.2",
  "strip-ansi-escapes",
  "thiserror 2.0.11",
- "uuid 1.11.1",
+ "uuid 1.12.0",
 ]
 
 [[package]]
@@ -7311,9 +7325,9 @@ dependencies = [
 
 [[package]]
 name = "revm"
-version = "19.2.0"
+version = "19.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b829dc9d6e62c5a540dfdceb0c4d2217e445bf5f6f5ed3866817e7a9637c019"
+checksum = "0a5a57589c308880c0f89ebf68d92aeef0d51e1ed88867474f895f6fd0f25c64"
 dependencies = [
  "auto_impl",
  "cfg-if",
@@ -7345,9 +7359,9 @@ dependencies = [
 
 [[package]]
 name = "revm-interpreter"
-version = "15.0.0"
+version = "15.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5ff76b50b5a9fa861fbc236fc82ce1afdf58861f65012aea807d679e54630d6"
+checksum = "c0f632e761f171fb2f6ace8d1552a5793e0350578d4acec3e79ade1489f4c2a6"
 dependencies = [
  "revm-primitives",
  "serde",
@@ -8201,13 +8215,13 @@ dependencies = [
 
 [[package]]
 name = "simple_asn1"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adc4e5204eb1910f40f9cfa375f6f05b68c3abac4b6fd879c8ff5e7ae8a0a085"
+checksum = "297f631f50729c8c99b84667867963997ec0b50f32b2a7dbcab828ef0541e8bb"
 dependencies = [
  "num-bigint",
  "num-traits",
- "thiserror 1.0.69",
+ "thiserror 2.0.11",
  "time",
 ]
 
@@ -8440,7 +8454,7 @@ dependencies = [
  "thiserror 2.0.11",
  "tokio",
  "toml_edit",
- "uuid 1.11.1",
+ "uuid 1.12.0",
  "zip",
  "zip-extract",
 ]
@@ -9472,9 +9486,9 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.11.1"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b913a3b5fe84142e269d63cc62b64319ccaf89b748fc31fe025177f767a756c4"
+checksum = "744018581f9a3454a9e15beb8a33b017183f1e7c0cd170232a2d1453b23a51c4"
 dependencies = [
  "getrandom",
  "serde",
@@ -9572,20 +9586,21 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a474f6281d1d70c17ae7aa6a613c87fce69a127e2624002df63dcb39d6cf6396"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
 dependencies = [
  "cfg-if",
  "once_cell",
+ "rustversion",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f89bb38646b4f81674e8f5c3fb81b562be1fd936d84320f3264486418519c79"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
 dependencies = [
  "bumpalo",
  "log",
@@ -9597,9 +9612,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.49"
+version = "0.4.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38176d9b44ea84e9184eff0bc34cc167ed044f816accfe5922e54d84cf48eca2"
+checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -9610,9 +9625,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cc6181fd9a7492eef6fef1f33961e3695e4579b9872a6f7c83aee556666d4fe"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -9620,9 +9635,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30d7a95b763d3c45903ed6c81f156801839e5ee968bb07e534c44df0fcd330c2"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9633,9 +9648,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "943aab3fdaaa029a6e0271b35ea10b72b943135afe9bffca82384098ad0e06a6"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "wasm-streams"
@@ -9729,9 +9747,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.76"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04dd7223427d52553d3702c004d3b2fe07c148165faa56313cb00211e31c12bc"
+checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -9807,22 +9825,22 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
-version = "0.56.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1de69df01bdf1ead2f4ac895dc77c9351aefff65b2f3db429a343f9cbf05e132"
-dependencies = [
- "windows-core 0.56.0",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows"
 version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
 dependencies = [
  "windows-core 0.58.0",
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f919aee0a93304be7f62e8e5027811bbba96bcb1de84d6618be56e43f8a32a1"
+dependencies = [
+ "windows-core 0.59.0",
+ "windows-targets 0.53.0",
 ]
 
 [[package]]
@@ -9836,18 +9854,6 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
-version = "0.56.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4698e52ed2d08f8658ab0c39512a7c00ee5fe2688c65f8c0a4f06750d729f2a6"
-dependencies = [
- "windows-implement 0.56.0",
- "windows-interface 0.56.0",
- "windows-result 0.1.2",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-core"
 version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
@@ -9855,19 +9861,21 @@ dependencies = [
  "windows-implement 0.58.0",
  "windows-interface 0.58.0",
  "windows-result 0.2.0",
- "windows-strings",
+ "windows-strings 0.1.0",
  "windows-targets 0.52.6",
 ]
 
 [[package]]
-name = "windows-implement"
-version = "0.56.0"
+name = "windows-core"
+version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6fc35f58ecd95a9b71c4f2329b911016e6bec66b3f2e6a4aad86bd2e99e2f9b"
+checksum = "810ce18ed2112484b0d4e15d022e5f598113e220c53e373fb31e67e21670c1ce"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.96",
+ "windows-implement 0.59.0",
+ "windows-interface 0.59.0",
+ "windows-result 0.3.0",
+ "windows-strings 0.3.0",
+ "windows-targets 0.53.0",
 ]
 
 [[package]]
@@ -9882,10 +9890,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-interface"
-version = "0.56.0"
+name = "windows-implement"
+version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08990546bf4edef8f431fa6326e032865f27138718c587dc21bc0265bbcb57cc"
+checksum = "83577b051e2f49a058c308f17f273b570a6a758386fc291b5f6a934dd84e48c1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9904,22 +9912,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-interface"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb26fd936d991781ea39e87c3a27285081e3c0da5ca0fcbc02d368cc6f52ff01"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
+]
+
+[[package]]
 name = "windows-registry"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0"
 dependencies = [
  "windows-result 0.2.0",
- "windows-strings",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
-dependencies = [
+ "windows-strings 0.1.0",
  "windows-targets 0.52.6",
 ]
 
@@ -9933,6 +9943,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-result"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d08106ce80268c4067c0571ca55a9b4e9516518eaa1a1fe9b37ca403ae1d1a34"
+dependencies = [
+ "windows-targets 0.53.0",
+]
+
+[[package]]
 name = "windows-strings"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9940,6 +9959,15 @@ checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
 dependencies = [
  "windows-result 0.2.0",
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b888f919960b42ea4e11c2f408fadb55f78a9f236d5eef084103c8ce52893491"
+dependencies = [
+ "windows-targets 0.53.0",
 ]
 
 [[package]]
@@ -9993,11 +10021,27 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1e4c7e8ceaaf9cb7d7507c974735728ab453b67ef8f18febdd7c11fe59dca8b"
+dependencies = [
+ "windows_aarch64_gnullvm 0.53.0",
+ "windows_aarch64_msvc 0.53.0",
+ "windows_i686_gnu 0.53.0",
+ "windows_i686_gnullvm 0.53.0",
+ "windows_i686_msvc 0.53.0",
+ "windows_x86_64_gnu 0.53.0",
+ "windows_x86_64_gnullvm 0.53.0",
+ "windows_x86_64_msvc 0.53.0",
 ]
 
 [[package]]
@@ -10013,6 +10057,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10023,6 +10073,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -10037,10 +10093,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -10055,6 +10123,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10065,6 +10139,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -10079,6 +10159,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10089,6 +10175,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winnow"

--- a/crates/forge/tests/cli/multi_script.rs
+++ b/crates/forge/tests/cli/multi_script.rs
@@ -6,7 +6,7 @@ use foundry_test_utils::{ScriptOutcome, ScriptTester};
 forgetest_async!(can_deploy_multi_chain_script_without_lib, |prj, cmd| {
     let (api1, handle1) = spawn(NodeConfig::test()).await;
     let (api2, handle2) = spawn(NodeConfig::test()).await;
-    let mut tester = ScriptTester::new_broadcast_without_endpoint(cmd, prj.root());
+    let mut tester = ScriptTester::new_broadcast_without_endpoint(&mut cmd, prj.root());
 
     tester
         .load_private_keys(&[0, 1])
@@ -25,7 +25,7 @@ forgetest_async!(can_deploy_multi_chain_script_without_lib, |prj, cmd| {
 forgetest_async!(can_not_deploy_multi_chain_script_with_lib, |prj, cmd| {
     let (_, handle1) = spawn(NodeConfig::test()).await;
     let (_, handle2) = spawn(NodeConfig::test()).await;
-    let mut tester = ScriptTester::new_broadcast_without_endpoint(cmd, prj.root());
+    let mut tester = ScriptTester::new_broadcast_without_endpoint(&mut cmd, prj.root());
 
     tester
         .load_private_keys(&[0, 1])
@@ -39,7 +39,7 @@ forgetest_async!(can_not_deploy_multi_chain_script_with_lib, |prj, cmd| {
 forgetest_async!(can_not_change_fork_during_broadcast, |prj, cmd| {
     let (_, handle1) = spawn(NodeConfig::test()).await;
     let (_, handle2) = spawn(NodeConfig::test()).await;
-    let mut tester = ScriptTester::new_broadcast_without_endpoint(cmd, prj.root());
+    let mut tester = ScriptTester::new_broadcast_without_endpoint(&mut cmd, prj.root());
 
     tester
         .load_private_keys(&[0, 1])
@@ -53,7 +53,7 @@ forgetest_async!(can_not_change_fork_during_broadcast, |prj, cmd| {
 forgetest_async!(can_resume_multi_chain_script, |prj, cmd| {
     let (_, handle1) = spawn(NodeConfig::test()).await;
     let (_, handle2) = spawn(NodeConfig::test()).await;
-    let mut tester = ScriptTester::new_broadcast_without_endpoint(cmd, prj.root());
+    let mut tester = ScriptTester::new_broadcast_without_endpoint(&mut cmd, prj.root());
 
     tester
         .add_sig("MultiChainBroadcastNoLink", "deploy(string memory,string memory)")

--- a/crates/forge/tests/cli/script.rs
+++ b/crates/forge/tests/cli/script.rs
@@ -672,7 +672,7 @@ ONCHAIN EXECUTION COMPLETE & SUCCESSFUL.
 
 forgetest_async!(can_deploy_script_without_lib, |prj, cmd| {
     let (_api, handle) = spawn(NodeConfig::test()).await;
-    let mut tester = ScriptTester::new_broadcast(cmd, &handle.http_endpoint(), prj.root());
+    let mut tester = ScriptTester::new_broadcast(&mut cmd, &handle.http_endpoint(), prj.root());
 
     tester
         .load_private_keys(&[0, 1])
@@ -686,7 +686,7 @@ forgetest_async!(can_deploy_script_without_lib, |prj, cmd| {
 
 forgetest_async!(can_deploy_script_with_lib, |prj, cmd| {
     let (_api, handle) = spawn(NodeConfig::test()).await;
-    let mut tester = ScriptTester::new_broadcast(cmd, &handle.http_endpoint(), prj.root());
+    let mut tester = ScriptTester::new_broadcast(&mut cmd, &handle.http_endpoint(), prj.root());
 
     tester
         .load_private_keys(&[0, 1])
@@ -700,7 +700,7 @@ forgetest_async!(can_deploy_script_with_lib, |prj, cmd| {
 
 forgetest_async!(can_deploy_script_private_key, |prj, cmd| {
     let (_api, handle) = spawn(NodeConfig::test()).await;
-    let mut tester = ScriptTester::new_broadcast(cmd, &handle.http_endpoint(), prj.root());
+    let mut tester = ScriptTester::new_broadcast(&mut cmd, &handle.http_endpoint(), prj.root());
 
     tester
         .load_addresses(&[Address::from_str("0x90F79bf6EB2c4f870365E785982E1f101E93b906").unwrap()])
@@ -717,7 +717,7 @@ forgetest_async!(can_deploy_script_private_key, |prj, cmd| {
 
 forgetest_async!(can_deploy_unlocked, |prj, cmd| {
     let (_api, handle) = spawn(NodeConfig::test()).await;
-    let mut tester = ScriptTester::new_broadcast(cmd, &handle.http_endpoint(), prj.root());
+    let mut tester = ScriptTester::new_broadcast(&mut cmd, &handle.http_endpoint(), prj.root());
 
     tester
         .sender("0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266".parse().unwrap())
@@ -729,7 +729,7 @@ forgetest_async!(can_deploy_unlocked, |prj, cmd| {
 
 forgetest_async!(can_deploy_script_remember_key, |prj, cmd| {
     let (_api, handle) = spawn(NodeConfig::test()).await;
-    let mut tester = ScriptTester::new_broadcast(cmd, &handle.http_endpoint(), prj.root());
+    let mut tester = ScriptTester::new_broadcast(&mut cmd, &handle.http_endpoint(), prj.root());
 
     tester
         .load_addresses(&[Address::from_str("0x90F79bf6EB2c4f870365E785982E1f101E93b906").unwrap()])
@@ -746,7 +746,7 @@ forgetest_async!(can_deploy_script_remember_key, |prj, cmd| {
 
 forgetest_async!(can_deploy_script_remember_key_and_resume, |prj, cmd| {
     let (_api, handle) = spawn(NodeConfig::test()).await;
-    let mut tester = ScriptTester::new_broadcast(cmd, &handle.http_endpoint(), prj.root());
+    let mut tester = ScriptTester::new_broadcast(&mut cmd, &handle.http_endpoint(), prj.root());
 
     tester
         .add_deployer(0)
@@ -770,7 +770,7 @@ forgetest_async!(can_deploy_script_remember_key_and_resume, |prj, cmd| {
 
 forgetest_async!(can_resume_script, |prj, cmd| {
     let (_api, handle) = spawn(NodeConfig::test()).await;
-    let mut tester = ScriptTester::new_broadcast(cmd, &handle.http_endpoint(), prj.root());
+    let mut tester = ScriptTester::new_broadcast(&mut cmd, &handle.http_endpoint(), prj.root());
 
     tester
         .load_private_keys(&[0])
@@ -788,7 +788,7 @@ forgetest_async!(can_resume_script, |prj, cmd| {
 
 forgetest_async!(can_deploy_broadcast_wrap, |prj, cmd| {
     let (_api, handle) = spawn(NodeConfig::test()).await;
-    let mut tester = ScriptTester::new_broadcast(cmd, &handle.http_endpoint(), prj.root());
+    let mut tester = ScriptTester::new_broadcast(&mut cmd, &handle.http_endpoint(), prj.root());
 
     tester
         .add_deployer(2)
@@ -803,7 +803,7 @@ forgetest_async!(can_deploy_broadcast_wrap, |prj, cmd| {
 
 forgetest_async!(panic_no_deployer_set, |prj, cmd| {
     let (_api, handle) = spawn(NodeConfig::test()).await;
-    let mut tester = ScriptTester::new_broadcast(cmd, &handle.http_endpoint(), prj.root());
+    let mut tester = ScriptTester::new_broadcast(&mut cmd, &handle.http_endpoint(), prj.root());
 
     tester
         .load_private_keys(&[0, 1])
@@ -815,7 +815,7 @@ forgetest_async!(panic_no_deployer_set, |prj, cmd| {
 
 forgetest_async!(can_deploy_no_arg_broadcast, |prj, cmd| {
     let (_api, handle) = spawn(NodeConfig::test()).await;
-    let mut tester = ScriptTester::new_broadcast(cmd, &handle.http_endpoint(), prj.root());
+    let mut tester = ScriptTester::new_broadcast(&mut cmd, &handle.http_endpoint(), prj.root());
 
     tester
         .add_deployer(0)
@@ -830,7 +830,7 @@ forgetest_async!(can_deploy_no_arg_broadcast, |prj, cmd| {
 
 forgetest_async!(can_deploy_with_create2, |prj, cmd| {
     let (api, handle) = spawn(NodeConfig::test()).await;
-    let mut tester = ScriptTester::new_broadcast(cmd, &handle.http_endpoint(), prj.root());
+    let mut tester = ScriptTester::new_broadcast(&mut cmd, &handle.http_endpoint(), prj.root());
 
     // Prepare CREATE2 Deployer
     api.anvil_set_code(
@@ -855,7 +855,7 @@ forgetest_async!(can_deploy_with_create2, |prj, cmd| {
 
 forgetest_async!(can_deploy_with_custom_create2, |prj, cmd| {
     let (api, handle) = spawn(NodeConfig::test()).await;
-    let mut tester = ScriptTester::new_broadcast(cmd, &handle.http_endpoint(), prj.root());
+    let mut tester = ScriptTester::new_broadcast(&mut cmd, &handle.http_endpoint(), prj.root());
     let create2 = Address::from_str("0x0000000000000000000000000000000000b4956c").unwrap();
 
     // Prepare CREATE2 Deployer
@@ -881,7 +881,7 @@ forgetest_async!(can_deploy_with_custom_create2, |prj, cmd| {
 
 forgetest_async!(can_deploy_with_custom_create2_notmatched_bytecode, |prj, cmd| {
     let (api, handle) = spawn(NodeConfig::test()).await;
-    let mut tester = ScriptTester::new_broadcast(cmd, &handle.http_endpoint(), prj.root());
+    let mut tester = ScriptTester::new_broadcast(&mut cmd, &handle.http_endpoint(), prj.root());
     let create2 = Address::from_str("0x0000000000000000000000000000000000b4956c").unwrap();
 
     // Prepare CREATE2 Deployer
@@ -904,7 +904,7 @@ forgetest_async!(can_deploy_with_custom_create2_notmatched_bytecode, |prj, cmd| 
 
 forgetest_async!(canot_deploy_with_nonexist_create2, |prj, cmd| {
     let (_api, handle) = spawn(NodeConfig::test()).await;
-    let mut tester = ScriptTester::new_broadcast(cmd, &handle.http_endpoint(), prj.root());
+    let mut tester = ScriptTester::new_broadcast(&mut cmd, &handle.http_endpoint(), prj.root());
     let create2 = Address::from_str("0x0000000000000000000000000000000000b4956c").unwrap();
 
     tester
@@ -919,7 +919,7 @@ forgetest_async!(canot_deploy_with_nonexist_create2, |prj, cmd| {
 
 forgetest_async!(can_deploy_and_simulate_25_txes_concurrently, |prj, cmd| {
     let (_api, handle) = spawn(NodeConfig::test()).await;
-    let mut tester = ScriptTester::new_broadcast(cmd, &handle.http_endpoint(), prj.root());
+    let mut tester = ScriptTester::new_broadcast(&mut cmd, &handle.http_endpoint(), prj.root());
 
     tester
         .load_private_keys(&[0])
@@ -933,7 +933,7 @@ forgetest_async!(can_deploy_and_simulate_25_txes_concurrently, |prj, cmd| {
 
 forgetest_async!(can_deploy_and_simulate_mixed_broadcast_modes, |prj, cmd| {
     let (_api, handle) = spawn(NodeConfig::test()).await;
-    let mut tester = ScriptTester::new_broadcast(cmd, &handle.http_endpoint(), prj.root());
+    let mut tester = ScriptTester::new_broadcast(&mut cmd, &handle.http_endpoint(), prj.root());
 
     tester
         .load_private_keys(&[0])
@@ -947,7 +947,7 @@ forgetest_async!(can_deploy_and_simulate_mixed_broadcast_modes, |prj, cmd| {
 
 forgetest_async!(deploy_with_setup, |prj, cmd| {
     let (_api, handle) = spawn(NodeConfig::test()).await;
-    let mut tester = ScriptTester::new_broadcast(cmd, &handle.http_endpoint(), prj.root());
+    let mut tester = ScriptTester::new_broadcast(&mut cmd, &handle.http_endpoint(), prj.root());
 
     tester
         .load_private_keys(&[0])
@@ -961,7 +961,7 @@ forgetest_async!(deploy_with_setup, |prj, cmd| {
 
 forgetest_async!(fail_broadcast_staticcall, |prj, cmd| {
     let (_api, handle) = spawn(NodeConfig::test()).await;
-    let mut tester = ScriptTester::new_broadcast(cmd, &handle.http_endpoint(), prj.root());
+    let mut tester = ScriptTester::new_broadcast(&mut cmd, &handle.http_endpoint(), prj.root());
 
     tester
         .load_private_keys(&[0])
@@ -972,7 +972,7 @@ forgetest_async!(fail_broadcast_staticcall, |prj, cmd| {
 
 forgetest_async!(check_broadcast_log, |prj, cmd| {
     let (api, handle) = spawn(NodeConfig::test()).await;
-    let mut tester = ScriptTester::new_broadcast(cmd, &handle.http_endpoint(), prj.root());
+    let mut tester = ScriptTester::new_broadcast(&mut cmd, &handle.http_endpoint(), prj.root());
 
     // Prepare CREATE2 Deployer
     let addr = Address::from_str("0x4e59b44847b379578588920ca78fbf26c0b4956c").unwrap();
@@ -1043,7 +1043,7 @@ forgetest_async!(check_broadcast_log, |prj, cmd| {
 
 forgetest_async!(test_default_sender_balance, |prj, cmd| {
     let (_api, handle) = spawn(NodeConfig::test()).await;
-    let mut tester = ScriptTester::new_broadcast(cmd, &handle.http_endpoint(), prj.root());
+    let mut tester = ScriptTester::new_broadcast(&mut cmd, &handle.http_endpoint(), prj.root());
 
     // Expect the default sender to have uint256.max balance.
     tester
@@ -1053,7 +1053,7 @@ forgetest_async!(test_default_sender_balance, |prj, cmd| {
 
 forgetest_async!(test_custom_sender_balance, |prj, cmd| {
     let (_api, handle) = spawn(NodeConfig::test()).await;
-    let mut tester = ScriptTester::new_broadcast(cmd, &handle.http_endpoint(), prj.root());
+    let mut tester = ScriptTester::new_broadcast(&mut cmd, &handle.http_endpoint(), prj.root());
 
     // Expect the sender to have its starting balance.
     tester
@@ -1365,13 +1365,13 @@ result: uint256 255
 });
 
 forgetest_async!(can_run_script_with_empty_setup, |prj, cmd| {
-    let mut tester = ScriptTester::new_broadcast_without_endpoint(cmd, prj.root());
+    let mut tester = ScriptTester::new_broadcast_without_endpoint(&mut cmd, prj.root());
 
     tester.add_sig("BroadcastEmptySetUp", "run()").simulate(ScriptOutcome::OkNoEndpoint);
 });
 
 forgetest_async!(does_script_override_correctly, |prj, cmd| {
-    let mut tester = ScriptTester::new_broadcast_without_endpoint(cmd, prj.root());
+    let mut tester = ScriptTester::new_broadcast_without_endpoint(&mut cmd, prj.root());
 
     tester.add_sig("CheckOverrides", "run()").simulate(ScriptOutcome::OkNoEndpoint);
 });
@@ -1462,6 +1462,57 @@ Script ran successfully.
 If you wish to simulate on-chain transactions pass a RPC URL.
 
 "#]]);
+});
+
+forgetest_async!(can_save_standard_json_in_broadcast, |prj, cmd| {
+    let (_api, handle) = spawn(NodeConfig::test()).await;
+    let mut tester = ScriptTester::new_broadcast(&mut cmd, &handle.http_endpoint(), prj.root());
+    tester.simulate(ScriptOutcome::OkSimulation);
+
+    // Add a simple script that we'll use to test standard-json saving
+    let script = prj
+        .add_source(
+            "StandardJson",
+            r#"
+contract Demo {
+    event log_string(string);
+    function run() external {
+        emit log_string("script ran");
+    }
+}
+"#,
+        )
+        .unwrap();
+
+    // Run the script with --save-standard-json
+    cmd.forge_fuse()
+        .arg("script")
+        .arg(script)
+        .arg("--save-standard-json")
+        .args([
+            "--broadcast",
+            "--private-key",
+            "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80",
+        ])
+        .assert_success();
+
+    // Find and read the broadcast file
+    let run_latest = foundry_common::fs::json_files(&prj.root().join("broadcast"))
+        .find(|file| file.ends_with("run-latest.json"))
+        .expect("No broadcast artifacts");
+
+    let content = foundry_common::fs::read_to_string(run_latest).unwrap();
+    let json: serde_json::Value = serde_json::from_str(&content).unwrap();
+
+    // Verify that standard-json exists and has expected structure
+    assert!(json.get("standard_json").is_some(), "standard_json field missing from broadcast file");
+    let standard_json = json.get("standard_json").unwrap().as_str().unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(standard_json).unwrap();
+
+    // Basic validation of standard-json structure
+    assert!(parsed.get("language").is_some(), "language field missing from standard-json");
+    assert!(parsed.get("sources").is_some(), "sources field missing from standard-json");
+    assert!(parsed.get("settings").is_some(), "settings field missing from standard-json");
 });
 
 forgetest_async!(assert_can_create_multiple_contracts_with_correct_nonce, |prj, cmd| {
@@ -1598,7 +1649,7 @@ If you wish to simulate on-chain transactions pass a RPC URL.
 
 forgetest_async!(assert_can_resume_with_additional_contracts, |prj, cmd| {
     let (_api, handle) = spawn(NodeConfig::test()).await;
-    let mut tester = ScriptTester::new_broadcast(cmd, &handle.http_endpoint(), prj.root());
+    let mut tester = ScriptTester::new_broadcast(&mut cmd, &handle.http_endpoint(), prj.root());
 
     tester
         .add_deployer(0)
@@ -1656,7 +1707,7 @@ contract ScriptC {{}}
     )
     .unwrap();
 
-    let mut tester = ScriptTester::new(cmd, None, prj.root(), "script/B.sol");
+    let mut tester = ScriptTester::new(&mut cmd, None, prj.root(), "script/B.sol");
     tester.cmd.forge_fuse().args(["script", "script/B.sol"]);
     tester.simulate(ScriptOutcome::OkNoEndpoint);
 });
@@ -1664,7 +1715,7 @@ contract ScriptC {{}}
 forgetest_async!(can_sign_with_script_wallet_single, |prj, cmd| {
     foundry_test_utils::util::initialize(prj.root());
 
-    let mut tester = ScriptTester::new_broadcast_without_endpoint(cmd, prj.root());
+    let mut tester = ScriptTester::new_broadcast_without_endpoint(&mut cmd, prj.root());
     tester
         .add_sig("ScriptSign", "run()")
         .load_private_keys(&[0])
@@ -1673,7 +1724,7 @@ forgetest_async!(can_sign_with_script_wallet_single, |prj, cmd| {
 });
 
 forgetest_async!(can_sign_with_script_wallet_multiple, |prj, cmd| {
-    let mut tester = ScriptTester::new_broadcast_without_endpoint(cmd, prj.root());
+    let mut tester = ScriptTester::new_broadcast_without_endpoint(&mut cmd, prj.root());
     let acc = tester.accounts_pub[0].to_checksum(None);
     tester
         .add_sig("ScriptSign", "run(address)")
@@ -2130,7 +2181,7 @@ Script ran successfully.
 forgetest_async!(can_deploy_library_create2, |prj, cmd| {
     let (_api, handle) = spawn(NodeConfig::test()).await;
 
-    let mut tester = ScriptTester::new_broadcast(cmd, &handle.http_endpoint(), prj.root());
+    let mut tester = ScriptTester::new_broadcast(&mut cmd, &handle.http_endpoint(), prj.root());
 
     tester
         .load_private_keys(&[0, 1])
@@ -2158,7 +2209,7 @@ forgetest_async!(can_deploy_library_create2, |prj, cmd| {
 forgetest_async!(can_deploy_library_create2_different_sender, |prj, cmd| {
     let (_api, handle) = spawn(NodeConfig::test()).await;
 
-    let mut tester = ScriptTester::new_broadcast(cmd, &handle.http_endpoint(), prj.root());
+    let mut tester = ScriptTester::new_broadcast(&mut cmd, &handle.http_endpoint(), prj.root());
 
     tester
         .load_private_keys(&[0, 1])

--- a/crates/script-sequence/src/sequence.rs
+++ b/crates/script-sequence/src/sequence.rs
@@ -37,6 +37,8 @@ pub struct ScriptSequence {
     pub timestamp: u64,
     pub chain: u64,
     pub commit: Option<String>,
+    /// The standard JSON input used for compilation, if --save-standard-json was enabled
+    pub standard_json: Option<String>,
 }
 
 /// Sensitive values from the transactions in a script sequence

--- a/crates/script/src/build.rs
+++ b/crates/script/src/build.rs
@@ -225,11 +225,19 @@ impl PreprocessedState {
 
         let target = target_id.ok_or_eyre("Could not find target contract")?;
 
+        // Generate standard JSON input if requested
+        let standard_json = if args.save_standard_json {
+            Some(serde_json::to_string(&project.standard_json_input(&target_path)?)?)
+        } else {
+            None
+        };
+
         Ok(CompiledState {
             args,
             script_config,
             script_wallets,
             build_data: BuildData { output, target, project_root: project.root().clone() },
+            standard_json,
         })
     }
 }
@@ -240,16 +248,18 @@ pub struct CompiledState {
     pub script_config: ScriptConfig,
     pub script_wallets: Wallets,
     pub build_data: BuildData,
+    /// The standard JSON input used for compilation, if --save-standard-json was enabled
+    pub standard_json: Option<String>,
 }
 
 impl CompiledState {
     /// Uses provided sender address to compute library addresses and link contracts with them.
     pub async fn link(self) -> Result<LinkedState> {
-        let Self { args, script_config, script_wallets, build_data } = self;
+        let Self { args, script_config, script_wallets, build_data, standard_json } = self;
 
         let build_data = build_data.link(&script_config).await?;
 
-        Ok(LinkedState { args, script_config, script_wallets, build_data })
+        Ok(LinkedState { args, script_config, script_wallets, build_data, standard_json })
     }
 
     /// Tries loading the resumed state from the cache files, skipping simulation stage.

--- a/crates/script/src/execute.rs
+++ b/crates/script/src/execute.rs
@@ -43,6 +43,7 @@ pub struct LinkedState {
     pub script_config: ScriptConfig,
     pub script_wallets: Wallets,
     pub build_data: LinkedBuildData,
+    pub standard_json: Option<String>,
 }
 
 /// Container for data we need for execution which can only be obtained after linking stage.
@@ -62,7 +63,7 @@ impl LinkedState {
     /// Given linked and compiled artifacts, prepares data we need for execution.
     /// This includes the function to call and the calldata to pass to it.
     pub async fn prepare_execution(self) -> Result<PreExecutionState> {
-        let Self { args, script_config, script_wallets, build_data } = self;
+        let Self { args, script_config, script_wallets, build_data, standard_json: _ } = self;
 
         let target_contract = build_data.get_target_contract()?;
 
@@ -123,6 +124,7 @@ impl PreExecutionState {
                 script_config: self.script_config,
                 script_wallets: self.script_wallets,
                 build_data: self.build_data.build_data,
+                standard_json: None,
             };
 
             return Box::pin(state.link().await?.prepare_execution().await?.execute()).await;

--- a/crates/script/src/lib.rs
+++ b/crates/script/src/lib.rs
@@ -216,6 +216,11 @@ pub struct ScriptArgs {
 
     #[command(flatten)]
     pub retry: RetryArgs,
+
+    /// Save the complete standard-json which is generated prior to compilation in the broadcast
+    /// files.
+    #[arg(long)]
+    pub save_standard_json: bool,
 }
 
 impl ScriptArgs {

--- a/crates/script/src/simulate.rs
+++ b/crates/script/src/simulate.rs
@@ -450,6 +450,7 @@ impl FilledTransactionsState {
             libraries,
             chain,
             commit,
+            standard_json: None,
         };
         Ok(sequence)
     }

--- a/crates/test-utils/src/script.rs
+++ b/crates/test-utils/src/script.rs
@@ -39,29 +39,29 @@ fn init_script_cmd(
     }
 }
 /// A helper struct to test forge script scenarios
-pub struct ScriptTester {
+pub struct ScriptTester<'a> {
     pub accounts_pub: Vec<Address>,
     pub accounts_priv: Vec<String>,
     pub provider: Option<RetryProvider>,
     pub nonces: BTreeMap<u32, u64>,
     pub address_nonces: BTreeMap<Address, u64>,
-    pub cmd: TestCommand,
+    pub cmd: &'a mut TestCommand,
     pub project_root: PathBuf,
     pub target_contract: String,
     pub endpoint: Option<String>,
 }
 
-impl ScriptTester {
+impl<'a> ScriptTester<'a> {
     /// Creates a new instance of a Tester for the given contract
     pub fn new(
-        mut cmd: TestCommand,
+        cmd: &'a mut TestCommand,
         endpoint: Option<&str>,
         project_root: &Path,
         target_contract: &str,
     ) -> Self {
         init_tracing();
         Self::copy_testdata(project_root).unwrap();
-        init_script_cmd(&mut cmd, project_root, target_contract, endpoint);
+        init_script_cmd(cmd, project_root, target_contract, endpoint);
 
         let mut provider = None;
         if let Some(endpoint) = endpoint {
@@ -91,7 +91,7 @@ impl ScriptTester {
 
     /// Creates a new instance of a Tester for the `broadcast` test at the given `project_root` by
     /// configuring the `TestCommand` with script
-    pub fn new_broadcast(cmd: TestCommand, endpoint: &str, project_root: &Path) -> Self {
+    pub fn new_broadcast(cmd: &'a mut TestCommand, endpoint: &str, project_root: &Path) -> Self {
         let target_contract = project_root.join(BROADCAST_TEST_PATH).to_string_lossy().to_string();
 
         // copy the broadcast test
@@ -106,7 +106,7 @@ impl ScriptTester {
 
     /// Creates a new instance of a Tester for the `broadcast` test at the given `project_root` by
     /// configuring the `TestCommand` with script without an endpoint
-    pub fn new_broadcast_without_endpoint(cmd: TestCommand, project_root: &Path) -> Self {
+    pub fn new_broadcast_without_endpoint(cmd: &'a mut TestCommand, project_root: &Path) -> Self {
         let target_contract = project_root.join(BROADCAST_TEST_PATH).to_string_lossy().to_string();
 
         // copy the broadcast test
@@ -256,7 +256,7 @@ impl ScriptTester {
 
     pub fn clear(&mut self) {
         init_script_cmd(
-            &mut self.cmd,
+            self.cmd,
             &self.project_root,
             &self.target_contract,
             self.endpoint.as_deref(),


### PR DESCRIPTION
Adds the --save-standard-json flag to forge script command to enable saving the complete standard-json which is generated prior to compilation in the broadcast files.

Changes:
- Added --save-standard-json flag to ScriptArgs
- Added standard_json field to ScriptSequence
- Modified build/execute/simulate logic to handle standard_json
- Added test case for standard_json saving
- Fixed ScriptTester mutable references

